### PR TITLE
Adapt portable_endian.hpp for GNU/Hurd

### DIFF
--- a/cpp/lazperf/portable_endian.hpp
+++ b/cpp/lazperf/portable_endian.hpp
@@ -12,7 +12,7 @@
 
 // use standard posix style headers for apple emscripten builds as well since emscripten sdk now ships its own
 // libc headers
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__EMSCRIPTEN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__EMSCRIPTEN__) || defined(__GNU__)
 
 #   include <endian.h>
 


### PR DESCRIPTION
Use `<endian.h>`, as available from GNU libc.