### PR TITLE
Extractor: fix reading of null-terminated strings

### DIFF
--- a/cpp/lazperf/Extractor.hpp
+++ b/cpp/lazperf/Extractor.hpp
@@ -117,16 +117,15 @@ public:
     {
         s = std::string(m_gptr, size);
         m_gptr += size;
-        while (size)
+        // end the string on first zero char
+        for ( size_t i = 0; i < size; ++i )
         {
-            size--;
-            if (s[size] != '\0')
+            if ( s[i] == '\0' )
             {
-                s.resize(size + 1);
-                return;
+                s.resize( i );
+                break;
             }
         }
-        s.clear();
     }
 
     /**


### PR DESCRIPTION
If a string field has some noise after zero-termination, e.g.

![Noise after zero](https://github.com/user-attachments/assets/cac58dfe-a59c-45ba-b08e-bb0a4bedd471)

the size of string is determined incorrectly, and the noise is included in it.

This pull-request resolves it.